### PR TITLE
Fix package requirements

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -4,7 +4,7 @@
 ;; Author: Yaroslav Shirokov
 ;; URL: https://github.com/sshirokov/ZNC.el
 ;; Version: 0.0.3
-;; Package-Requires: ((cl "2.2") (erc "5.3"))
+;; Package-Requires: ((cl-lib "2.2") (erc "5.3"))
 ;; Also available via Marmalade http://marmalade-repo.org/
 ;;;;;;
 (require 'cl)


### PR DESCRIPTION
Recent Emacs versions only supply version number for cl-lib package. Without this change I'm unable to install ZNC.el from marmalade.
