### PR TITLE
Fix cl-lib package require

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -4,7 +4,7 @@
 ;; Author: Yaroslav Shirokov
 ;; URL: https://github.com/sshirokov/ZNC.el
 ;; Version: 0.0.3
-;; Package-Requires: ((cl-lib "2.2") (erc "5.3"))
+;; Package-Requires: ((cl-lib "0.2") (erc "5.3"))
 ;; Also available via Marmalade http://marmalade-repo.org/
 ;;;;;;
 (require 'cl)


### PR DESCRIPTION
2.2 isn't actually a version:

`cl-lib.el`

```
;;; Change Log:

;; Version 2.02 (30 Jul 93):
```

To be fair, 0.2 doesn't seem to be a version either, but that's what [magit](https://github.com/magit/magit/blob/master/magit-pkg.el.in) and a host of other packages seem to use.

This fixes an issue where `znc` can't be installed using `package-install-packages`.
