### PR TITLE
package: remove erc 5.3 dependency since that breaks melpa

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -4,7 +4,7 @@
 ;; Author: Yaroslav Shirokov
 ;; URL: https://github.com/sshirokov/ZNC.el
 ;; Version: 0.0.3
-;; Package-Requires: ((cl-lib "0.2") (erc "5.3"))
+;; Package-Requires: ((cl-lib "0.2"))
 ;; Also available via Marmalade http://marmalade-repo.org/
 ;;;;;;
 (require 'cl)


### PR DESCRIPTION
ZNC.el is no longer installable via package.el without this
change. ERC has been included in emacs for a while, so we just
drop the explicit requirement.