### PR TITLE
Remove package dependency on ERC

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -4,7 +4,7 @@
 ;; Author: Yaroslav Shirokov
 ;; URL: https://github.com/sshirokov/ZNC.el
 ;; Version: 0.0.3
-;; Package-Requires: ((cl-lib "0.2") (erc "5.3"))
+;; Package-Requires: ((cl-lib "0.2"))
 ;; Also available via Marmalade http://marmalade-repo.org/
 ;;;;;;
 (require 'cl)


### PR DESCRIPTION
This bogus package dependency on a built-in library rendered this package uninstallable via MELPA. Better to fix this than remove `znc` from MELPA, so I figured I'd send you this fix.