### PR TITLE
loop-fix with erc

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -3,7 +3,7 @@
 
 ;; Author: Yaroslav Shirokov
 ;; URL: https://github.com/sshirokov/ZNC.el
-;; Version: 0.0.3
+;; Version: 0.0.4
 ;; Package-Requires: ((cl-lib "0.2"))
 ;; Also available via Marmalade http://marmalade-repo.org/
 ;;;;;;
@@ -115,8 +115,7 @@ some of the quirks that arise from using it with a naive ERC. "
           (with-current-buffer returning
             (znc-set-name wants-name)
             (rename-buffer wants-name))
-          (get-buffer wants-name))
-      returning)))
+	  returning))))
 
 (defadvice erc-kill-channel (around znc-maybe-dont-part first nil activate)
   "Maybe don't let `erc-kill-channel' run"


### PR DESCRIPTION
* From Emacs version 26 the get-buffer wants-name line (line 118 of
  ver. 0.0.3) produced this error:

  Warning (bytecomp): value returned from (get-buffer wants-name) is unused

* If left untended, subsequent attempts to load ERC with ZNC would
  result in an infinite loop of failing connection attempts which
  required shutting down the entire Emacs instance.  Removing that
  line and appending the remaining closeding parenthesis prevents the
  bytecomp warning, ERC requires further testing, though.