### PR TITLE
When prompting, don't use initial-input, use default

### DIFF
--- a/znc.el
+++ b/znc.el
@@ -228,7 +228,7 @@ to the matching values for the endpoint"
                      (rename-buffer buffer)))))
 
 (defun znc-prompt-string-or-nil (prompt &optional completions default require-match)
-  (let* ((string (completing-read (concat prompt ": ") completions nil require-match default))
+  (let* ((string (completing-read (concat prompt ": ") completions nil require-match nil nil default))
          (string (if (equal string "") nil string)))
     string))
 


### PR DESCRIPTION
The `initial-input` parameter of `completing-read` is deprecated. It is better to use the `default` parameter. It enables a user to directly type and complete its choice, without having to delete the initial input.